### PR TITLE
Enable \Illuminate\Database\Query\Builder and \Illuminate\Database\Eloquent\Builder

### DIFF
--- a/src/Grammars/EloquentBuilderGrammar.php
+++ b/src/Grammars/EloquentBuilderGrammar.php
@@ -2,20 +2,20 @@
 
 namespace AnourValar\EloquentSerialize\Grammars;
 
-use Illuminate\Database\Query\Builder;
-
 trait EloquentBuilderGrammar
 {
     /**
      * Serialize state for \Illuminate\Database\Eloquent\Builder
      *
-     * @param Builder $builder
+     * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return array
      */
-    protected function packEloquentBuilder(Builder $builder): array
+    protected function packEloquentBuilder(\Illuminate\Database\Eloquent\Builder $builder): array
     {
         return [
-            'removed_scopes' => $builder->removedScopes() // global scopes
+            'with' => $this->getEagers($builder), // preloaded ("eager") relations
+            'removed_scopes' => $builder->removedScopes(), // global scopes
+            'casts' => $builder->getModel()->getCasts(),
         ];
     }
 
@@ -23,10 +23,10 @@ trait EloquentBuilderGrammar
      * Unserialize state for \Illuminate\Database\Eloquent\Builder
      *
      * @param array $data
-     * @param Builder $builder
+     * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function unpackEloquentBuilder(array $data, Builder &$builder): void
+    protected function unpackEloquentBuilder(array $data, \Illuminate\Database\Eloquent\Builder &$builder): void
     {
         // Preloaded ("eager") relations
         $this->setEagers($builder, $data['with']);
@@ -43,10 +43,10 @@ trait EloquentBuilderGrammar
     }
 
     /**
-     * @param $builder
+     * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return array
      */
-    private function getEagers(Builder $builder): array
+    private function getEagers(\Illuminate\Database\Eloquent\Builder $builder): array
     {
         $result = [];
 

--- a/src/Grammars/EloquentBuilderGrammar.php
+++ b/src/Grammars/EloquentBuilderGrammar.php
@@ -2,20 +2,20 @@
 
 namespace AnourValar\EloquentSerialize\Grammars;
 
+use Illuminate\Database\Query\Builder;
+
 trait EloquentBuilderGrammar
 {
     /**
      * Serialize state for \Illuminate\Database\Eloquent\Builder
      *
-     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param Builder $builder
      * @return array
      */
-    protected function packEloquentBuilder(\Illuminate\Database\Eloquent\Builder $builder): array
+    protected function packEloquentBuilder(Builder $builder): array
     {
         return [
-            'with' => $this->getEagers($builder), // preloaded ("eager") relations
-            'removed_scopes' => $builder->removedScopes(), // global scopes
-            'casts' => $builder->getModel()->getCasts(),
+            'removed_scopes' => $builder->removedScopes() // global scopes
         ];
     }
 
@@ -23,10 +23,10 @@ trait EloquentBuilderGrammar
      * Unserialize state for \Illuminate\Database\Eloquent\Builder
      *
      * @param array $data
-     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param Builder $builder
      * @return void
      */
-    protected function unpackEloquentBuilder(array $data, \Illuminate\Database\Eloquent\Builder &$builder): void
+    protected function unpackEloquentBuilder(array $data, Builder &$builder): void
     {
         // Preloaded ("eager") relations
         $this->setEagers($builder, $data['with']);
@@ -43,10 +43,10 @@ trait EloquentBuilderGrammar
     }
 
     /**
-     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param $builder
      * @return array
      */
-    private function getEagers(\Illuminate\Database\Eloquent\Builder $builder): array
+    private function getEagers(Builder $builder): array
     {
         $result = [];
 

--- a/src/Grammars/ModelGrammar.php
+++ b/src/Grammars/ModelGrammar.php
@@ -2,21 +2,21 @@
 
 namespace AnourValar\EloquentSerialize\Grammars;
 
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
 trait ModelGrammar
 {
     /**
      * Pack
      *
-     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param Builder $builder
      * @return \AnourValar\EloquentSerialize\Package
      */
-    protected function pack(\Illuminate\Database\Eloquent\Builder $builder): \AnourValar\EloquentSerialize\Package
+    protected function pack($builder): \AnourValar\EloquentSerialize\Package
     {
         return new \AnourValar\EloquentSerialize\Package([
-            'model' => get_class($builder->getModel()),
-            'connection' => $builder->getModel()->getConnectionName(),
-            'eloquent' => $this->packEloquentBuilder($builder),
-            'query' => $this->packQueryBuilder($builder->getQuery()),
+            'query' => $this->packQueryBuilder($builder),
         ]);
     }
 
@@ -26,13 +26,11 @@ trait ModelGrammar
      * @param \AnourValar\EloquentSerialize\Package $package
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function unpack(\AnourValar\EloquentSerialize\Package $package): \Illuminate\Database\Eloquent\Builder
+    protected function unpack(\AnourValar\EloquentSerialize\Package $package)
     {
-        $builder = $package->get('model');
-        $builder = $builder::on($package->get('connection'));
+        $builder = DB::connection($package->get('connection'))->table('notOfInterest');
 
-        $this->unpackEloquentBuilder($package->get('eloquent'), $builder);
-        $this->unpackQueryBuilder($package->get('query'), $builder->getQuery());
+        $this->unpackQueryBuilder($package->get('query'), $builder);
 
         return $builder;
     }

--- a/src/Grammars/QueryBuilderGrammar.php
+++ b/src/Grammars/QueryBuilderGrammar.php
@@ -91,7 +91,7 @@ trait QueryBuilderGrammar
 
         foreach ($unions as &$item) {
             if (isset($item['query'])) {
-                $item['query'] = $this->pack($item['query']);
+                $item['query'] = $this->packEloquent($item['query']);
             }
         }
         unset($item);

--- a/src/Service.php
+++ b/src/Service.php
@@ -2,7 +2,7 @@
 
 namespace AnourValar\EloquentSerialize;
 
-use Illuminate\Database\Query\Builder;
+use Nette\NotImplementedException;
 
 class Service
 {
@@ -12,12 +12,22 @@ class Service
 
     /**
      * Pack
+     * @param \Illuminate\Database\Query\Builder | \Illuminate\Database\Eloquent\Builder $builder
      *
      * @return string
      */
-    public function serialize(Builder $builder): string
+    public function serialize($builder): string
     {
-        $package = $this->pack($builder);
+        switch (true) {
+            case $builder instanceof \Illuminate\Database\Query\Builder:
+                $package = $this->packQuery($builder);
+                break;
+            case $builder instanceof \Illuminate\Database\Eloquent\Builder:
+                $package = $this->packEloquent($builder);
+                break;
+            default:
+                throw new NotImplementedException('No implementation found for build (' . get_class($builder) . ')');
+        }
 
         return serialize($package); // important!
     }
@@ -27,9 +37,9 @@ class Service
      *
      * @param mixed $package
      * @throws \LogicException
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder | \Illuminate\Database\Eloquent\Builder
      */
-    public function unserialize($package): Builder
+    public function unserialize($package)
     {
         // Prepare data
         if (is_string($package)) {

--- a/src/Service.php
+++ b/src/Service.php
@@ -2,6 +2,8 @@
 
 namespace AnourValar\EloquentSerialize;
 
+use Illuminate\Database\Query\Builder;
+
 class Service
 {
     use \AnourValar\EloquentSerialize\Grammars\ModelGrammar;
@@ -11,10 +13,9 @@ class Service
     /**
      * Pack
      *
-     * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return string
      */
-    public function serialize(\Illuminate\Database\Eloquent\Builder $builder): string
+    public function serialize(Builder $builder): string
     {
         $package = $this->pack($builder);
 
@@ -26,9 +27,9 @@ class Service
      *
      * @param mixed $package
      * @throws \LogicException
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Query\Builder
      */
-    public function unserialize($package): \Illuminate\Database\Eloquent\Builder
+    public function unserialize($package): Builder
     {
         // Prepare data
         if (is_string($package)) {


### PR DESCRIPTION
Thanks a lot for this package. It was exactly the feature I needed! :-)

But I am using the Query\Builder quite generic and therefore had to extend this package for my own.

My changes are aimed at allowing both eloquent and the query builder to be used, and then serializing only part of the information accordingly.

Unfortunately I did not manage to run the unit tests (error message: Illuminate\Database\QueryException : could not find driver (SQL: PRAGMA foreign_keys = OFF;)). Do you have a small instruction, what must be done, so that these also run?

Best regards
Sebastian

Translated with www.DeepL.com/Translator (free version)