### PR TITLE
Add github workflows to run tests automatically

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,56 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                php: [8.3, 8.2, 8.1, 8.0]
+                laravel: [11.*, 10.*, 9.*, 8.*]
+                stability: [prefer-stable]
+                include:
+                    -   laravel: 11.*
+                        testbench: 9.*
+                    -   laravel: 10.*
+                        testbench: 8.*
+                    -   laravel: 9.*
+                        testbench: 7.*
+                    -   laravel: 8.*
+                        testbench: 6.23
+                exclude:
+                    -   laravel: 11.*
+                        php: 8.1
+                    -   laravel: 11.*
+                        php: 8.0
+                    -   laravel: 10.*
+                        php: 8.0
+
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                    coverage: none
+
+            - name: Setup problem matchers
+              run: |
+                  echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+                  echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Install dependencies
+                run: |
+                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+            -   name: Execute tests
+                run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "license": "MIT",
     "require": {
         "php": "^7.1|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0"
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|^4.0|^5.0|^6.0|^7.0|^8.0",
+        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
         "laravel/legacy-factories": "^1.1",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.26",


### PR DESCRIPTION
The only package remaining for https://github.com/filamentphp/filament/pull/10972 to be merged is eloquent-serialize now.

This adds Laravel 11 support and adds Github workflows to run tests with every push and PR.

I wasn't sure if I could add commits to https://github.com/AnourValar/eloquent-serialize/pull/14 so I created this.
@atmonshi feel free to add the workflows to your PR and we can close this.

The checks are currently failing because Psalm doesn't support Laravel 11.
I've also created a PR to add Laravel 11 support to Psalm.
https://github.com/psalm/psalm-plugin-laravel/pull/362