### PR TITLE
Lateral join support

### DIFF
--- a/src/Grammars/QueryBuilderGrammar.php
+++ b/src/Grammars/QueryBuilderGrammar.php
@@ -116,10 +116,13 @@ trait QueryBuilderGrammar
         }
 
         foreach ($joins as &$item) {
-            $item = array_replace(
-                ['type' => $item->type, 'table' => $item->table],
-                $this->packQueryBuilder($item)
-            );
+            $head = ['type' => $item->type, 'table' => $item->table];
+
+            if ($item instanceof \Illuminate\Database\Query\JoinLateralClause) {
+                $head['lateral'] = true;
+            }
+
+            $item = array_replace($head, $this->packQueryBuilder($item));
         }
         unset($item);
 
@@ -179,8 +182,12 @@ trait QueryBuilderGrammar
         }
 
         foreach ($joins as &$item) {
-            $parentQuery = new \Illuminate\Database\Query\JoinClause($builder, $item['type'], $item['table']);
-            unset($item['type'], $item['table']);
+            $class = !empty($item['lateral'])
+                ? \Illuminate\Database\Query\JoinLateralClause::class
+                : \Illuminate\Database\Query\JoinClause::class;
+
+            $parentQuery = new $class($builder, $item['type'], $item['table']);
+            unset($item['type'], $item['table'], $item['lateral']);
 
             $item = $this->unpackQueryBuilder($item, $parentQuery);
         }

--- a/tests/JoinTest.php
+++ b/tests/JoinTest.php
@@ -85,4 +85,36 @@ class JoinTest extends AbstractSuite
             })
         );
     }
+
+    /**
+     * @return void
+     */
+    public function testLateralSubQuery()
+    {
+        if (!method_exists(User::query()->getQuery(), 'leftJoinLateral')) {
+            $this->markTestSkipped('Laravel 11.0+ feature');
+        }
+
+        config(['database.default' => 'pgsql']);
+
+        $latestPost = Post::select('title')
+            ->whereColumn('posts.user_id', 'users.id')
+            ->orderByDesc('created_at')
+            ->limit(1);
+
+        $this->compare(
+            User::query()
+                ->select('users.*')
+                ->addSelect('latest_post.title')
+                ->leftJoinLateral($latestPost, 'latest_post'),
+            false
+        );
+
+        $this->compare(
+            User::query()
+                ->select('users.*')
+                ->joinLateral($latestPost, 'latest_post'),
+            false
+        );
+    }
 }


### PR DESCRIPTION
When serializing query with lateral join it was unserializing using the wrong JoinClause class. it will not serialize with a flag indicating the join is lateral and unserialize depending if the flag exists otherwise fall back to previous.